### PR TITLE
Run the appropriate help command for npm, grunt or gulp.

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -11,17 +11,34 @@ fi
 echo "Installing NPM dependencies"
 npm install
 
-# First try Gulp, then try Grunt
+# Install and run JavaScript build tools.
+# First try Gulp, then try Grunt. Default to npm.
 if [ -f "gulpfile.js" ]
 then 
   npm install -g gulp-cli
-  echo "Running Gulp default task"
-  sh -c "gulp $*"
+  if [ "$*" = "--help" ]
+  then
+    # List the gulp tasks available, then exit with a config error.
+    # This gives the user info about the args available, but also 
+    # lets them know we haven't really done anything.
+    # See https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses
+    sh -c "gulp --tasks" && exit 78
+  else
+    echo "Running gulp with args"
+    sh -c "gulp $*"
+  fi
 elif [ -f "Gruntfile.js" ]
 then 
   npm install -g grunt-cli
-  echo "Running Grunt default task"
+  echo "Running grunt with args"
   sh -c "grunt $*"
 else
-  echo "Neither Gruntfile nor gulpfile found. Nothing to execute."
+  if [ "$*" = "--help" ]
+  then
+    # List the npm scripts available, then exit with a config error.
+    sh -c "npm run" && exit 78
+  else
+    echo "Running npm with args"
+    sh -c "npm $*"
+  fi
 fi


### PR DESCRIPTION
Also translate --help arg to something that shows the scripts available
for each cli tool:

`grunt --help` works for grunt. This is set as the default for the action.
`gulp --tasks` works for gulp
`npm run` shows npm scripts 