### PR TITLE
commit: remove 'refs/heads/' from GITHUB_REF only.

### DIFF
--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-## This GitHub Action for git commits any changed files and pushes 
+## This GitHub Action for git commits any changed files and pushes
 ## those changes back to the origin repository.
 ##
 ## Required environment variable:
-## - $GITHUB_TOKEN: The token to use for authentication with GitHub 
+## - $GITHUB_TOKEN: The token to use for authentication with GitHub
 ## to commit and push changes back to the origin repository.
 ##
 ## Optional environment variables:
@@ -44,20 +44,20 @@ EOF
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config user.name "$GITHUB_ACTOR"
-  
+
   # Push to the current branch if PUSH_BRANCH hasn't been overriden
-  : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $3 }' `}
+  : ${PUSH_BRANCH:=${GITHUB_REF/refs\/heads\//}}
 }
 
 # This section only runs if there have been file changes
 echo "Checking for uncommitted changes in the git working tree."
 if ! git diff --quiet
-then 
+then
   git_setup
   git checkout $PUSH_BRANCH
   git add .
   git commit -m $COMMIT_MESSAGE
   git push --set-upstream origin $PUSH_BRANCH
-else 
+else
   echo "Working tree clean. Nothing to commit."
 fi

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -25,12 +25,12 @@ fi
 if [ ! -z "$WD_PATH" ]
 then
   echo "Changing dir to $WD_PATH"
-  cd $WD_PATH
+  cd "$WD_PATH"
 fi
 
 # Set up .netrc file with GitHub credentials
 git_setup ( ) {
-  cat <<- EOF > $HOME/.netrc
+  cat <<- EOF > "$HOME/.netrc"
 		machine github.com
 		login $GITHUB_ACTOR
 		password $GITHUB_TOKEN
@@ -39,14 +39,14 @@ git_setup ( ) {
 		login $GITHUB_ACTOR
 		password $GITHUB_TOKEN
 EOF
-  chmod 600 $HOME/.netrc
+  chmod 600 "$HOME/.netrc"
 
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config user.name "$GITHUB_ACTOR"
 
   # Push to the current branch if PUSH_BRANCH hasn't been overriden
-  : ${PUSH_BRANCH:=${GITHUB_REF/refs\/heads\//}}
+  : ${PUSH_BRANCH:="${GITHUB_REF/refs\/heads\//}"}
 }
 
 # This section only runs if there have been file changes
@@ -54,10 +54,10 @@ echo "Checking for uncommitted changes in the git working tree."
 if ! git diff --quiet
 then
   git_setup
-  git checkout $PUSH_BRANCH
+  git checkout "$PUSH_BRANCH"
   git add .
-  git commit -m $COMMIT_MESSAGE
-  git push --set-upstream origin $PUSH_BRANCH
+  git commit -m "$COMMIT_MESSAGE"
+  git push --set-upstream origin "$PUSH_BRANCH"
 else
   echo "Working tree clean. Nothing to commit."
 fi


### PR DESCRIPTION
The 'awk' way of doing this meant a ref like 'refs/heads/parkr/foobar' would turn into 'parkr'
instead of into 'parkr/foobar'.

```shell
~$ GITHUB_REF="refs/heads/foo/bar"
~$ echo $GITHUB_REF
refs/heads/foo/bar
~$ echo "$GITHUB_REF" | awk -F / '{ print $3 }'
foo
~$ echo ${GITHUB_REF/refs\/heads\//}
foo/bar
```

/cc @elstudio 