### PR TITLE
Update commit to work with actions/checkout@v2-beta.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Perfect for Grunt or Gulp tasks that do CSS (or SASS/LESS) compilation or JS tra
 
 This repository contains two actions that may be used independently -- typically one after another:
 
-- **build** (elstudio/actions-js-build/build@master): Looks for a gulpfile.js or Gruntfile.js in the working directory, then installs any required npm packages and runs the appropriate build tool. If it finds neither gulp or grunt, the script runs npm. Set the workflow `args` arguments to run the tasks of your choice.
-- **commit** (elstudio/actions-js-build/commit@master): Commits any file changes, and pushes them back to the current branch of the origin repository on GitHub.
+- **build** (elstudio/actions-js-build/build@v2): Looks for a gulpfile.js or Gruntfile.js in the working directory, then installs any required npm packages and runs the appropriate build tool. If it finds neither gulp or grunt, the script runs npm. Set the workflow `args` arguments to run the tasks of your choice.
+- **commit** (elstudio/actions-js-build/commit@v2): Commits any file changes, and pushes them back to the current branch of the origin repository on GitHub.
 
 
 ## Usage
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2-beta
 
     - name: Compile with Grunt
       uses: elstudio/actions-js-build/build@v2

--- a/commit/README.md
+++ b/commit/README.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2-beta
 
     - name: Compile with Grunt
       uses: elstudio/actions-js-build/build@v2
@@ -40,7 +40,7 @@ jobs:
 
 ### Inputs 
 
-* `commitMessage` - **Optional**. Git Commit Message. Defaults to *Regenerate build artifacts.`
+* `commitMessage` - **Optional**. Git Commit Message. Defaults to "Regenerate build artifacts."
 * `wdPath` - **Optional**. To specify a directory other than the repository root to check for changed files.
 * `pushBranch` - **Optional**. The branch that changes will be pushed to. Default is the currently checked out branch.
 

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -25,7 +25,7 @@ fi
 if [ ! -z "$WD_PATH" ]
 then
   echo "Changing dir to $WD_PATH"
-  cd $WD_PATH
+  cd "$WD_PATH"
 fi
 
 # Set up .netrc file with GitHub credentials
@@ -46,7 +46,7 @@ EOF
   git config user.name "$GITHUB_ACTOR"
   
   # Push to the current branch if PUSH_BRANCH hasn't been overriden
-  : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $3 }' `}
+  : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
 }
 
 # This section only runs if there have been file changes
@@ -56,7 +56,7 @@ then
   git_setup
   # git checkout $PUSH_BRANCH
   git add .
-  git commit -m $COMMIT_MESSAGE
+  git commit -m "$COMMIT_MESSAGE"
   # git push --set-upstream origin $PUSH_BRANCH
   git push
 else 

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -56,9 +56,10 @@ echo "Checking for uncommitted changes in the git working tree."
 if expr $(git status --porcelain | wc -l) \> 0
 then 
   git_setup
+  git checkout "$PUSH_BRANCH"
   git add .
   git commit -m "$COMMIT_MESSAGE"
-  git push
+  git push --set-upstream origin "$PUSH_BRANCH"
 else 
   echo "Working tree clean. Nothing to commit."
 fi

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -54,10 +54,11 @@ echo "Checking for uncommitted changes in the git working tree."
 if ! git diff --quiet
 then 
   git_setup
-  git checkout $PUSH_BRANCH
+  # git checkout $PUSH_BRANCH
   git add .
   git commit -m $COMMIT_MESSAGE
-  git push --set-upstream origin $PUSH_BRANCH
+  # git push --set-upstream origin $PUSH_BRANCH
+  git push
 else 
   echo "Working tree clean. Nothing to commit."
 fi

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -51,7 +51,7 @@ EOF
 
 # This section only runs if there have been file changes
 echo "Checking for uncommitted changes in the git working tree."
-if ! git diff --quiet
+if expr $(git status --porcelain | wc -l) > 0
 then 
   git_setup
   # git checkout $PUSH_BRANCH

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -46,19 +46,18 @@ EOF
   git config user.name "$GITHUB_ACTOR"
   
   # Push to the current branch if PUSH_BRANCH hasn't been overriden
+  # Actions/checkout@v2-beta and later make this unnecessary
   : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
+  echo "PUSH_BRANCH=$PUSH_BRANCH"
 }
 
 # This section only runs if there have been file changes
 echo "Checking for uncommitted changes in the git working tree."
-if expr $(git status --porcelain | wc -l) > 0
+if expr $(git status --porcelain | wc -l) \> 0
 then 
   git_setup
-  # git checkout $PUSH_BRANCH
-  echo $PUSH_BRANCH
   git add .
   git commit -m "$COMMIT_MESSAGE"
-  # git push --set-upstream origin $PUSH_BRANCH
   git push
 else 
   echo "Working tree clean. Nothing to commit."

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -55,6 +55,7 @@ if expr $(git status --porcelain | wc -l) > 0
 then 
   git_setup
   # git checkout $PUSH_BRANCH
+  echo $PUSH_BRANCH
   git add .
   git commit -m "$COMMIT_MESSAGE"
   # git push --set-upstream origin $PUSH_BRANCH


### PR DESCRIPTION
actions/checkout@v2-beta automatically checks out the working tree, so we no longer need to explicitly check out our branch or push to a custom upstream.

For now, this version explicitly checks out the PUSH_BRANCH, although that is no longer necessary with checkout@v2. Leaving the explicit checkout and set upstream commands in place means that this version of the script is compatible with actions/checkout@v1 and actions/checkout@v2.

- Check for (and commit) both new and changed files. Fixes #5 
- Improve the branch name detection to fix #6 
- Allow spaces in commit messages. Fixes #4