### PR TITLE
v3 release requires actions/checkout@v2-beta or later

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,23 +33,16 @@ jobs:
         wdPath: './web/themes/nw8'
 
     - name: Commit changes
-      uses: elstudio/actions-js-build/commit@v2
+      uses: elstudio/actions-js-build/commit@v3
       with:
-        pushBranch: staging
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        commitMessage: Regenerate css 
 ```
 
 
-### Secrets
 
-* `GITHUB_TOKEN` - **Required**. The token to use for authentication with GitHub to commit and push changes back to the origin repository. ([more info](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables))
+### Inputs
 
-
-### Environment variables
-
-* `WD_PATH` - **Optional**. To specify a directory other than the repository root where NPM's Package.json and either gulpfile.js or Gruntfile.js may be found.
-* `PUSH_BRANCH` - **Optional**. The branch that changes will be pushed to. Default is the currently checked out branch.
+* `wdPath` - **Optional**. To specify a directory other than the repository root where NPM's Package.json and either gulpfile.js or Gruntfile.js may be found.
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
 
     - name: Compile with Grunt
       uses: elstudio/actions-js-build/build@v2

--- a/build/README.md
+++ b/build/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
 
     - name: Compile with Grunt
       uses: elstudio/actions-js-build/build@v2

--- a/build/README.md
+++ b/build/README.md
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2-beta
 
     - name: Compile with Grunt
       uses: elstudio/actions-js-build/build@v2
@@ -32,11 +32,9 @@ jobs:
         wdPath: './web/themes/nw8'
 
     - name: Commit changes
-      uses: elstudio/actions-js-build/commit@v2
+      uses: elstudio/actions-js-build/commit@v3
       with:
-        pushBranch: staging 
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        commitMessage: Regenerate css 
 ```
 
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -2,6 +2,8 @@
 
 This Action for git commits any changed files and pushes those changes back to the origin repository.
 
+**V3 of this action (elstudio/actions-js-build/commit@v3) requires actions/checkout@v2-beta or later.**
+
 ## Usage
 
 An example workflow to commit and push any changes back to the GitHub origin repository:

--- a/commit/README.md
+++ b/commit/README.md
@@ -28,23 +28,15 @@ jobs:
         wdPath: './web/themes/nw8'
 
     - name: Commit changes
-      uses: elstudio/actions-js-build/commit@v2
+      uses: elstudio/actions-js-build/commit@v3
       with:
-        pushBranch: staging
         commitMessage: Regenerate css 
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 ```
-
-### Secrets
-
-* `GITHUB_TOKEN` - **Required**. The token to use for authentication with GitHub to commit and push changes back to the origin repository. ([more info](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#environment-variables))
 
 ### Inputs 
 
 * `commitMessage` - **Optional**. Git Commit Message. Defaults to "Regenerate build artifacts."
 * `wdPath` - **Optional**. To specify a directory other than the repository root to check for changed files.
-* `pushBranch` - **Optional**. The branch that changes will be pushed to. Default is the currently checked out branch.
 
 ## License
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
 
     - name: Compile with Grunt
       uses: elstudio/actions-js-build/build@v2

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -9,9 +9,6 @@ inputs:
     description: 'Working directory path'
     required: false
     default: ''
-  pushBranch:
-    description: 'Override branch to push to'
-    requried: false
   debug:
     description: 'Print script debugging info'
     required: false
@@ -26,6 +23,5 @@ runs:
   env:
     DEBUG: ${{ inputs.debug }}
     WD_PATH: ${{ inputs.wdPath }}
-    PUSH_BRANCH: ${{ inputs.pushBranch }}
     COMMIT_MESSAGE: ${{ inputs.commitMessage }}
  

--- a/commit/action.yml
+++ b/commit/action.yml
@@ -23,5 +23,4 @@ runs:
   env:
     DEBUG: ${{ inputs.debug }}
     WD_PATH: ${{ inputs.wdPath }}
-    COMMIT_MESSAGE: ${{ inputs.commitMessage }}
- 
+    COMMIT_MESSAGE: ${{ inputs.commitMessage }} 

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -30,16 +30,16 @@ fi
 
 # Set up .netrc file with GitHub credentials
 git_setup ( ) {
-#   cat <<- EOF > "$HOME/.netrc"
-# 		machine github.com
-# 		login $GITHUB_ACTOR
-# 		password $GITHUB_TOKEN
+  cat <<- EOF > "$HOME/.netrc"
+		machine github.com
+		login $GITHUB_ACTOR
+		password $GITHUB_TOKEN
 
-# 		machine api.github.com
-# 		login $GITHUB_ACTOR
-# 		password $GITHUB_TOKEN
-# EOF
-#   chmod 600 "$HOME/.netrc"
+		machine api.github.com
+		login $GITHUB_ACTOR
+		password $GITHUB_TOKEN
+EOF
+  chmod 600 "$HOME/.netrc"
 
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
@@ -47,8 +47,8 @@ git_setup ( ) {
   
   # Push to the current branch if PUSH_BRANCH hasn't been overriden
   # Actions/checkout@v2-beta and later make this unnecessary
-  # : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
-  # echo "PUSH_BRANCH=$PUSH_BRANCH"
+  : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
+  echo "PUSH_BRANCH=$PUSH_BRANCH"
 }
 
 # This section only runs if there have been file changes

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -30,16 +30,16 @@ fi
 
 # Set up .netrc file with GitHub credentials
 git_setup ( ) {
-  cat <<- EOF > $HOME/.netrc
-		machine github.com
-		login $GITHUB_ACTOR
-		password $GITHUB_TOKEN
+#   cat <<- EOF > "$HOME/.netrc"
+# 		machine github.com
+# 		login $GITHUB_ACTOR
+# 		password $GITHUB_TOKEN
 
-		machine api.github.com
-		login $GITHUB_ACTOR
-		password $GITHUB_TOKEN
-EOF
-  chmod 600 $HOME/.netrc
+# 		machine api.github.com
+# 		login $GITHUB_ACTOR
+# 		password $GITHUB_TOKEN
+# EOF
+#   chmod 600 "$HOME/.netrc"
 
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
@@ -47,8 +47,8 @@ EOF
   
   # Push to the current branch if PUSH_BRANCH hasn't been overriden
   # Actions/checkout@v2-beta and later make this unnecessary
-  : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
-  echo "PUSH_BRANCH=$PUSH_BRANCH"
+  # : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
+  # echo "PUSH_BRANCH=$PUSH_BRANCH"
 }
 
 # This section only runs if there have been file changes
@@ -56,10 +56,11 @@ echo "Checking for uncommitted changes in the git working tree."
 if expr $(git status --porcelain | wc -l) \> 0
 then 
   git_setup
-  git checkout "$PUSH_BRANCH"
+  # git checkout "$PUSH_BRANCH"
   git add .
   git commit -m "$COMMIT_MESSAGE"
-  git push --set-upstream origin "$PUSH_BRANCH"
+  # git push --set-upstream origin "$PUSH_BRANCH"
+  git push
 else 
   echo "Working tree clean. Nothing to commit."
 fi

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -30,23 +30,12 @@ fi
 
 # Set up .netrc file with GitHub credentials
 git_setup ( ) {
-#   cat <<- EOF > "$HOME/.netrc"
-# 		machine github.com
-# 		login $GITHUB_ACTOR
-# 		password $GITHUB_TOKEN
-
-# 		machine api.github.com
-# 		login $GITHUB_ACTOR
-# 		password $GITHUB_TOKEN
-# EOF
-#   chmod 600 "$HOME/.netrc"
-
+  # Since actions/checkout@v2-beta we no longer need login credentials.
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config user.name "$GITHUB_ACTOR"
   
-  # Push to the current branch if PUSH_BRANCH hasn't been overriden
-  # Actions/checkout@v2-beta and later make this unnecessary
+  # Push to the current branch if PUSH_BRANCH hasn't been specified
   : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
   echo "PUSH_BRANCH=$PUSH_BRANCH"
 }
@@ -56,11 +45,12 @@ echo "Checking for uncommitted changes in the git working tree."
 if expr $(git status --porcelain | wc -l) \> 0
 then 
   git_setup
-  # git checkout "$PUSH_BRANCH"
+  # Actions/checkout@v2-beta and later make this unnecessary
+  git checkout "$PUSH_BRANCH"
   git add .
   git commit -m "$COMMIT_MESSAGE"
-  # git push --set-upstream origin "$PUSH_BRANCH"
-  git push
+  # Actions/checkout@v2-beta and later mean a straight git push should work
+  git push --set-upstream origin "$PUSH_BRANCH"
 else 
   echo "Working tree clean. Nothing to commit."
 fi

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -30,14 +30,9 @@ fi
 
 # Set up .netrc file with GitHub credentials
 git_setup ( ) {
-  # Since actions/checkout@v2-beta we no longer need login credentials.
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
   git config user.name "$GITHUB_ACTOR"
-  
-  # Push to the current branch if PUSH_BRANCH hasn't been specified
-  : ${PUSH_BRANCH:=`echo "$GITHUB_REF" | awk -F / '{ print $NF }' `}
-  echo "PUSH_BRANCH=$PUSH_BRANCH"
 }
 
 # This section only runs if there have been file changes
@@ -45,12 +40,9 @@ echo "Checking for uncommitted changes in the git working tree."
 if expr $(git status --porcelain | wc -l) \> 0
 then 
   git_setup
-  # Actions/checkout@v2-beta and later make this unnecessary
-  git checkout "$PUSH_BRANCH"
   git add .
   git commit -m "$COMMIT_MESSAGE"
-  # Actions/checkout@v2-beta and later mean a straight git push should work
-  git push --set-upstream origin "$PUSH_BRANCH"
+  git push
 else 
   echo "Working tree clean. Nothing to commit."
 fi

--- a/commit/entrypoint.sh
+++ b/commit/entrypoint.sh
@@ -30,16 +30,16 @@ fi
 
 # Set up .netrc file with GitHub credentials
 git_setup ( ) {
-  cat <<- EOF > "$HOME/.netrc"
-		machine github.com
-		login $GITHUB_ACTOR
-		password $GITHUB_TOKEN
+#   cat <<- EOF > "$HOME/.netrc"
+# 		machine github.com
+# 		login $GITHUB_ACTOR
+# 		password $GITHUB_TOKEN
 
-		machine api.github.com
-		login $GITHUB_ACTOR
-		password $GITHUB_TOKEN
-EOF
-  chmod 600 "$HOME/.netrc"
+# 		machine api.github.com
+# 		login $GITHUB_ACTOR
+# 		password $GITHUB_TOKEN
+# EOF
+#   chmod 600 "$HOME/.netrc"
 
   # Git requires our "name" and email address -- use GitHub handle
   git config user.email "$GITHUB_ACTOR@users.noreply.github.com"


### PR DESCRIPTION
Since actions/checkout@v2-beta improves credential handling, let's not duplicate those efforts.

This will be a v3 release that changes the following arguments:

- Removes the PUSH_BRANCH argument. If you need this, please use the `ref` argument of actions/checkout@v2-beta or later
- Removes the GITHUB_TOKEN argument, since it's now provided by checkout@v2
- Requires actions/checkout@v2-beta or later
