### PR TITLE
Upgrades to relieve some issues I ran into. 

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,5 +13,5 @@ COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
 
 COPY "entrypoint.sh" "/entrypoint.sh"
-ENTRYPOINT ["/bin/bash/", "/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 CMD ["default"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.11.1
+FROM node:14.4.0-stretch
 
 LABEL version="1.0.0"
 LABEL repository="https://github.com/elstudio/actions-js-build"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:12.18-alpine
 
 LABEL version="1.0.0"
 LABEL repository="https://github.com/elstudio/actions-js-build"

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,5 +13,5 @@ COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
 
 COPY "entrypoint.sh" "/entrypoint.sh"
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash/", "/entrypoint.sh"]
 CMD ["default"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12.18-alpine
+FROM node:12.11.1
 
 LABEL version="1.0.0"
 LABEL repository="https://github.com/elstudio/actions-js-build"
@@ -11,8 +11,6 @@ LABEL com.github.actions.icon="truck"
 LABEL com.github.actions.color="purple"
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
-
-RUN apk --update --no-cache add git
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -11,6 +11,9 @@ LABEL com.github.actions.icon="truck"
 LABEL com.github.actions.color="purple"
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
+
+RUN apk --update --no-cache add git
+
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["default"]

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -17,7 +17,7 @@ then
   echo "Changing dir to $WD_PATH"
   cd $WD_PATH
 fi
-
+echo $PWD 
 echo "Installing NPM dependencies"
 npm install
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -19,7 +19,7 @@ then
 fi
 echo $PWD 
 echo "Installing NPM dependencies"
-npm install
+npm ci
 
 
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -21,20 +21,9 @@ echo $PWD
 echo "Installing NPM dependencies"
 npm install
 
-# First try Gulp, then try Grunt
-# Gulpfile.js can be a file or a directory:
-if [ -e "gulpfile.js" ]
-then 
-  npm install -g gulp-cli
-  echo "Running Gulp with args"
-  sh -c "gulp $*"
-# Gruntfile can be js or coffeescript file
-elif [ -f "Gruntfile.js" -o -f "Gruntfile.coffee" ]
-then 
-  npm install -g grunt-cli
-  echo "Running Grunt with args"
-  sh -c "grunt $*"
-else
-  echo "Running NPM with args"
-  sh -c "npm $*"
-fi
+
+
+npm install -g gulp-cli
+echo "Running Gulp with args"
+sh -c "gulp $*"
+


### PR DESCRIPTION
1. Not sure if this is necessary, but I changed to a different version of node. I was running into issues with alpine, because they didn't have npm dependencies. Probably could have just installed them using apk but since, size of the container doesn't really matter, I opted to use a more robust OS. 

2. Switched to an explicit call to bash because in this os it couldn't infer which command to run the file with. Think it may have been trying to run node /entrypoint.sh which was throwing all kinds of errors. 

3. Changed npm install command to npm ci because it will handle if someone committed a lock file, which I did. Apparently npm ci is created specifically for this use case see the link below. 
[https://docs.npmjs.com/cli/ci.html](urhttps://docs.npmjs.com/cli/ci.html)

4. removed the gruntfile logic because I am explicitly using gulp but you can obviously leave that. 

