### PR TITLE
Add support for gulpfile.babel.js

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -23,7 +23,7 @@ npm install
 
 # First try Gulp, then try Grunt
 # Gulpfile.js can be a file or a directory:
-if [ -e "gulpfile.js" ]
+if [ -e "gulpfile.js" -o -f "gulpfile.babel.js" ]
 then 
   npm install -g gulp-cli
   echo "Running Gulp with args"


### PR DESCRIPTION
Gulp supports gulp files written in ES6 by simply naming the gulpfile `gulpfile.babel.js` if you have babel as a project dependency.