### PR TITLE
Added conditional to skip npm install

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -18,8 +18,11 @@ then
   cd $WD_PATH
 fi
 
-echo "Installing NPM dependencies"
-npm install
+if [ -z "$SKIP_INSTALL" ]
+then
+  echo "Installing NPM dependencies"
+  npm install
+fi
 
 # First try Gulp, then try Grunt
 # Gulpfile.js can be a file or a directory:


### PR DESCRIPTION
Added conditional to skip npm install, when using another steps to install the dependencies.

We already use a separated step to manage the dependencies, so setting up a flag to skip install would help in this case.